### PR TITLE
feat(server): support updating existing tasks

### DIFF
--- a/src/server/migrations/2019-09-03-135727_add_name_task_id_uniqueness_constraint_to_steps_table/down.sql
+++ b/src/server/migrations/2019-09-03-135727_add_name_task_id_uniqueness_constraint_to_steps_table/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE steps DROP CONSTRAINT steps_name_task_id_key;

--- a/src/server/migrations/2019-09-03-135727_add_name_task_id_uniqueness_constraint_to_steps_table/up.sql
+++ b/src/server/migrations/2019-09-03-135727_add_name_task_id_uniqueness_constraint_to_steps_table/up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE steps ADD UNIQUE (name, task_id);

--- a/src/server/migrations/2019-09-03-142055_add_key_task_id_uniqueness_constraint_to_variables_table/down.sql
+++ b/src/server/migrations/2019-09-03-142055_add_key_task_id_uniqueness_constraint_to_variables_table/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE variables DROP CONSTRAINT variables_key_task_id_key;

--- a/src/server/migrations/2019-09-03-142055_add_key_task_id_uniqueness_constraint_to_variables_table/up.sql
+++ b/src/server/migrations/2019-09-03-142055_add_key_task_id_uniqueness_constraint_to_variables_table/up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE variables ADD UNIQUE (key, task_id);

--- a/src/server/migrations/2019-09-03-154728_alter_position_task_id_uniqueness_constraint_for_steps_table/down.sql
+++ b/src/server/migrations/2019-09-03-154728_alter_position_task_id_uniqueness_constraint_for_steps_table/down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE steps DROP CONSTRAINT steps_position_task_id_key;
+ALTER TABLE steps ADD UNIQUE (position, task_id);

--- a/src/server/migrations/2019-09-03-154728_alter_position_task_id_uniqueness_constraint_for_steps_table/up.sql
+++ b/src/server/migrations/2019-09-03-154728_alter_position_task_id_uniqueness_constraint_for_steps_table/up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE steps DROP CONSTRAINT steps_position_task_id_key;
+ALTER TABLE steps ADD UNIQUE (position, task_id) DEFERRABLE INITIALLY IMMEDIATE;

--- a/src/server/migrations/2019-09-03-161047_alter_key_step_id_uniqueness_constraint_for_variable_advertisements_table/down.sql
+++ b/src/server/migrations/2019-09-03-161047_alter_key_step_id_uniqueness_constraint_for_variable_advertisements_table/down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE variable_advertisements DROP CONSTRAINT variable_advertisements_step_id_key;
+ALTER TABLE variable_advertisements ADD UNIQUE (key, step_id);

--- a/src/server/migrations/2019-09-03-161047_alter_key_step_id_uniqueness_constraint_for_variable_advertisements_table/up.sql
+++ b/src/server/migrations/2019-09-03-161047_alter_key_step_id_uniqueness_constraint_for_variable_advertisements_table/up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE variable_advertisements DROP CONSTRAINT variable_advertisements_key_step_id_key;
+ALTER TABLE variable_advertisements ADD UNIQUE (step_id);

--- a/src/server/schema.graphql
+++ b/src/server/schema.graphql
@@ -25,6 +25,7 @@ input CreateTaskInput {
   labels: [String!]
   variables: [CreateVariableInput!]
   steps: [CreateStepInput!]!
+  onConflict: OnConflict
 }
 
 input CreateVariableInput {

--- a/src/server/src/models/variable_advertisement.rs
+++ b/src/server/src/models/variable_advertisement.rs
@@ -36,10 +36,13 @@ impl<'a> NewVariableAdvertisement<'a> {
         Self { key, step_id }
     }
 
-    ///// Save the new variable advertisement in the database.
-    pub fn create(self, conn: &PgConnection) -> QueryResult<VariableAdvertisement> {
+    /// Save or update the variable advertisement in the database.
+    pub fn create_or_update(self, conn: &PgConnection) -> QueryResult<VariableAdvertisement> {
         diesel::insert_into(variable_advertisements::table)
             .values(&self)
+            .on_conflict(variable_advertisements::step_id)
+            .do_update()
+            .set(&self)
             .get_result(conn)
     }
 }

--- a/src/server/src/resources.rs
+++ b/src/server/src/resources.rs
@@ -5,7 +5,7 @@ mod step;
 mod task;
 pub(crate) mod variable;
 
-pub(crate) use global_variable::graphql::{GlobalVariableInput, OnConflict};
+pub(crate) use global_variable::graphql::GlobalVariableInput;
 pub(crate) use job::step::{
     JobStep, NewJobStep, Status as JobStepStatus, StatusMapping as JobStepStatusMapping,
 };
@@ -20,3 +20,10 @@ pub(crate) use task::{
     NewTask, Task,
 };
 pub(crate) use variable::{graphql::CreateVariableInput, NewVariable, Variable};
+
+/// Define what to do when a conflict occurs on object mutation.
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, juniper::GraphQLEnum)]
+pub(crate) enum OnConflict {
+    Abort,
+    Update,
+}

--- a/src/server/src/resources/global_variable.rs
+++ b/src/server/src/resources/global_variable.rs
@@ -1,3 +1,4 @@
+use super::OnConflict;
 use crate::models::NewGlobalVariable;
 use serde::{Deserialize, Serialize};
 
@@ -13,14 +14,7 @@ pub(crate) mod graphql {
     //! mutation, and type documentation.
 
     use super::*;
-    use juniper::{GraphQLEnum, GraphQLInputObject};
-
-    /// Define what to do when a conflict occurs on object mutation.
-    #[derive(Clone, Debug, Deserialize, Serialize, GraphQLEnum)]
-    pub(crate) enum OnConflict {
-        Abort,
-        Update,
-    }
+    use juniper::GraphQLInputObject;
 
     /// Create a new global variable.
     #[derive(Clone, Debug, Deserialize, Serialize, GraphQLInputObject)]


### PR DESCRIPTION
This change introduces the possibility to update tasks.

The implementation is similar to global variables introduced in
3932d5595a5705e3117d9f3535660cd912c066bc:

A new `onConflict` directive can be passed along with the task details.
It can be either `UPDATE` or `ABORT`, it defaults to `ABORT` if unset.

If set to `ABORT`, the behavior will be similar to the existing
behavior, and an error is returned if a similarly named task already
exists.

If set to `UPDATE`, the following semantics apply:

* If a task with a similar name **does not** yet exist, a new task is
  created (this also means that task names currently can't be renamed
  via the API, but they can be modified in the database directly).

* If a similarly named task name **does exist**:
    * its properties (description, labels) are updated,
    * its steps are matched using their names (you can update step
      names, but it will remove the old step, and create a new step,
      instead of updating the existing one),
    * step properties (description, processor, position,
      advertisedVariableKey) are updated,
    * missing steps are removed,
    * new steps are added,
    * the same rules apply to task variables, you can update their
      description, selectionConstraint, defaultValue and exampleValue.

There is no support in the client(s) yet for creating or updating tasks,
but using the exposed GraphQL API playground, you can achieve the same
results.